### PR TITLE
Add timezone preference for track history timestamps (#324)

### DIFF
--- a/atak/ATAK/app/src/main/java/com/atakmap/android/track/ui/TrackDateTimeFormatter.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/track/ui/TrackDateTimeFormatter.java
@@ -1,0 +1,37 @@
+
+package com.atakmap.android.track.ui;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class TrackDateTimeFormatter {
+
+    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+    public static TimeZone resolveTimeZone(String tzPref) {
+        if ("Local".equals(tzPref)) {
+            return TimeZone.getDefault();
+        }
+        return UTC;
+    }
+
+    public static String formatDate(long millis, TimeZone tz, Locale locale) {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", locale);
+        sdf.setTimeZone(tz);
+        return sdf.format(new Date(millis));
+    }
+
+    public static String formatTime(long millis, TimeZone tz, Locale locale) {
+        SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss", locale);
+        sdf.setTimeZone(tz);
+        String time = sdf.format(new Date(millis));
+        if ("UTC".equals(tz.getID())) {
+            return time + "Z";
+        }
+        return time + tz.getDisplayName(
+                tz.inDaylightTime(new Date(millis)),
+                TimeZone.SHORT, locale);
+    }
+}

--- a/atak/ATAK/app/src/main/java/com/atakmap/android/track/ui/TrackDetailsView.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/track/ui/TrackDetailsView.java
@@ -49,8 +49,6 @@ import com.atakmap.coremap.maps.coords.GeoPointMetaData;
 import com.atakmap.coremap.maps.time.CoordinatedTime;
 import com.atakmap.map.CameraController;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.TimeZone;
 
 public class TrackDetailsView extends LinearLayout implements
@@ -91,15 +89,13 @@ public class TrackDetailsView extends LinearLayout implements
     }
 
     public void setStartDateTime(long millis) {
-        Date d = new Date(millis);
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd",
-                LocaleUtil.getCurrent());
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        _startDate.setText(sdf.format(d));
-
-        sdf = new SimpleDateFormat("HH:mm:ss'Z'", LocaleUtil.getCurrent());
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        _startTime.setText(sdf.format(d));
+        String tzPref = _prefs.get("track_history_timezone", "UTC")
+                .toString();
+        TimeZone tz = TrackDateTimeFormatter.resolveTimeZone(tzPref);
+        _startDate.setText(TrackDateTimeFormatter.formatDate(
+                millis, tz, LocaleUtil.getCurrent()));
+        _startTime.setText(TrackDateTimeFormatter.formatTime(
+                millis, tz, LocaleUtil.getCurrent()));
     }
 
     @Override

--- a/atak/ATAK/app/src/main/res/values/arrays.xml
+++ b/atak/ATAK/app/src/main/res/values/arrays.xml
@@ -172,6 +172,16 @@
         <item>20</item>
     </string-array>
 
+    <string-array name="track_history_timezone_entries">
+        <item>UTC</item>
+        <item>Local Device Time</item>
+    </string-array>
+
+    <string-array translatable="false" name="track_history_timezone_values">
+        <item>UTC</item>
+        <item>Local</item>
+    </string-array>
+
     <string-array name="elevation_units_label">
         <item>@string/elevation_unit_feet</item>
         <item>@string/elevation_unit_meters</item>

--- a/atak/ATAK/app/src/main/res/values/strings.xml
+++ b/atak/ATAK/app/src/main/res/values/strings.xml
@@ -833,6 +833,8 @@
   <string name="kml_export_timestaps_summ">Check to use gx:Track with timestamps (more detailed info), uncheck to use LineString (more compatibility).</string>
   <string name="Server_track_time_gap_title">Server track time gap (minutes)</string>
   <string name="Server_track_time_gap_summ">When searching the server for tracks, split into separate tracks when consecutive breadcrumbs are temporally more than this far apart (default: 10 minutes).</string>
+  <string name="track_history_timezone_title">Track Time Zone</string>
+  <string name="track_history_timezone_summ">Time zone used for displaying track timestamps.</string>
   <string name="pers_self_track_title">Persistent Self Track</string>
   <string name="pers_self_track_summ">Check to display all tracks since startup.</string>
   <string name="set_max_num_of_crumbs_title">Set Max Number of Bread Crumbs</string>

--- a/atak/ATAK/app/src/main/res/xml/bread_preferences.xml
+++ b/atak/ATAK/app/src/main/res/xml/bread_preferences.xml
@@ -41,6 +41,13 @@
             android:title="@string/Server_track_time_gap_title"
             android:inputType = "number"
             android:defaultValue="10"/>
+        <com.atakmap.android.gui.PanListPreference
+            android:entries="@array/track_history_timezone_entries"
+            android:entryValues="@array/track_history_timezone_values"
+            android:key="track_history_timezone"
+            android:title="@string/track_history_timezone_title"
+            android:summary="@string/track_history_timezone_summ"
+            android:defaultValue="UTC"/>
    </PreferenceCategory>
    <PreferenceCategory
        android:title="@string/breadcrumbPreferences"

--- a/atak/ATAK/app/src/test/java/com/atakmap/android/track/ui/TrackDateTimeFormatterTest.java
+++ b/atak/ATAK/app/src/test/java/com/atakmap/android/track/ui/TrackDateTimeFormatterTest.java
@@ -1,0 +1,179 @@
+
+package com.atakmap.android.track.ui;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Locale;
+import java.util.TimeZone;
+
+import static org.junit.Assert.*;
+
+public class TrackDateTimeFormatterTest {
+
+    // 2021-01-01 00:00:00 UTC
+    private static final long MIDNIGHT_2021_UTC = 1609459200000L;
+
+    private TimeZone originalDefault;
+
+    @Before
+    public void setUp() {
+        originalDefault = TimeZone.getDefault();
+    }
+
+    @After
+    public void tearDown() {
+        TimeZone.setDefault(originalDefault);
+    }
+
+    // --- AC 1 & 3: Default/explicit UTC returns UTC-formatted date and "Z" suffix ---
+
+    @Test
+    public void test_resolveTimeZone_utc_returns_utc() {
+        TimeZone tz = TrackDateTimeFormatter.resolveTimeZone("UTC");
+        assertEquals("UTC", tz.getID());
+    }
+
+    @Test
+    public void test_formatDate_utc_returns_utc_date() {
+        TimeZone tz = TrackDateTimeFormatter.resolveTimeZone("UTC");
+        String date = TrackDateTimeFormatter.formatDate(
+                MIDNIGHT_2021_UTC, tz, Locale.US);
+        assertEquals("2021-01-01", date);
+    }
+
+    @Test
+    public void test_formatTime_utc_returns_z_suffix() {
+        TimeZone tz = TrackDateTimeFormatter.resolveTimeZone("UTC");
+        String time = TrackDateTimeFormatter.formatTime(
+                MIDNIGHT_2021_UTC, tz, Locale.US);
+        assertEquals("00:00:00Z", time);
+    }
+
+    // --- AC 2 & 5: "Local" with America/New_York returns local date and tz abbreviation ---
+
+    @Test
+    public void test_resolveTimeZone_local_returns_device_default() {
+        TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+        TimeZone tz = TrackDateTimeFormatter.resolveTimeZone("Local");
+        assertEquals("America/New_York", tz.getID());
+    }
+
+    @Test
+    public void test_formatDate_local_new_york_crosses_day_boundary() {
+        TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+        TimeZone tz = TrackDateTimeFormatter.resolveTimeZone("Local");
+        String date = TrackDateTimeFormatter.formatDate(
+                MIDNIGHT_2021_UTC, tz, Locale.US);
+        assertEquals("2020-12-31", date);
+    }
+
+    @Test
+    public void test_formatTime_local_new_york_shows_est() {
+        TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+        TimeZone tz = TrackDateTimeFormatter.resolveTimeZone("Local");
+        String time = TrackDateTimeFormatter.formatTime(
+                MIDNIGHT_2021_UTC, tz, Locale.US);
+        assertEquals("19:00:00EST", time);
+    }
+
+    // --- AC 3: Unrecognized preference value falls back to UTC ---
+
+    @Test
+    public void test_resolveTimeZone_unrecognized_falls_back_to_utc() {
+        TimeZone tz = TrackDateTimeFormatter.resolveTimeZone("garbage");
+        assertEquals("UTC", tz.getID());
+    }
+
+    @Test
+    public void test_resolveTimeZone_null_falls_back_to_utc() {
+        TimeZone tz = TrackDateTimeFormatter.resolveTimeZone(null);
+        assertEquals("UTC", tz.getID());
+    }
+
+    @Test
+    public void test_resolveTimeZone_empty_falls_back_to_utc() {
+        TimeZone tz = TrackDateTimeFormatter.resolveTimeZone("");
+        assertEquals("UTC", tz.getID());
+    }
+
+    // --- AC 4 (edge case): Exact midnight UTC ---
+
+    @Test
+    public void test_formatDate_exact_midnight_utc() {
+        TimeZone tz = TrackDateTimeFormatter.resolveTimeZone("UTC");
+        String date = TrackDateTimeFormatter.formatDate(
+                MIDNIGHT_2021_UTC, tz, Locale.US);
+        assertEquals("2021-01-01", date);
+    }
+
+    @Test
+    public void test_formatTime_exact_midnight_utc() {
+        TimeZone tz = TrackDateTimeFormatter.resolveTimeZone("UTC");
+        String time = TrackDateTimeFormatter.formatTime(
+                MIDNIGHT_2021_UTC, tz, Locale.US);
+        assertEquals("00:00:00Z", time);
+    }
+
+    // --- AC 5 (edge case): Positive offset timezone (Asia/Kolkata, UTC+5:30) ---
+
+    @Test
+    public void test_formatDate_kolkata_positive_offset() {
+        TimeZone tz = TimeZone.getTimeZone("Asia/Kolkata");
+        // 2021-01-01 00:00:00 UTC = 2021-01-01 05:30:00 IST
+        String date = TrackDateTimeFormatter.formatDate(
+                MIDNIGHT_2021_UTC, tz, Locale.US);
+        assertEquals("2021-01-01", date);
+    }
+
+    @Test
+    public void test_formatTime_kolkata_positive_offset() {
+        TimeZone tz = TimeZone.getTimeZone("Asia/Kolkata");
+        String time = TrackDateTimeFormatter.formatTime(
+                MIDNIGHT_2021_UTC, tz, Locale.US);
+        // IST = India Standard Time abbreviation; non-UTC so no "Z"
+        assertEquals("05:30:00IST", time);
+    }
+
+    @Test
+    public void test_formatDate_kolkata_positive_offset_crosses_day_forward() {
+        // 2020-12-31 20:00:00 UTC = 2021-01-01 01:30:00 IST
+        long dec31_2000_utc = MIDNIGHT_2021_UTC - (4 * 3600 * 1000L);
+        TimeZone tz = TimeZone.getTimeZone("Asia/Kolkata");
+        String date = TrackDateTimeFormatter.formatDate(
+                dec31_2000_utc, tz, Locale.US);
+        assertEquals("2021-01-01", date);
+    }
+
+    @Test
+    public void test_formatTime_kolkata_positive_offset_crosses_day_forward() {
+        long dec31_2000_utc = MIDNIGHT_2021_UTC - (4 * 3600 * 1000L);
+        TimeZone tz = TimeZone.getTimeZone("Asia/Kolkata");
+        String time = TrackDateTimeFormatter.formatTime(
+                dec31_2000_utc, tz, Locale.US);
+        assertEquals("01:30:00IST", time);
+    }
+
+    // --- Additional: UTC time suffix is literal "Z", not a timezone abbreviation ---
+
+    @Test
+    public void test_formatTime_utc_suffix_is_literal_z_not_abbreviation() {
+        TimeZone tz = TrackDateTimeFormatter.resolveTimeZone("UTC");
+        // Use a non-midnight time to verify suffix is always "Z" for UTC
+        long nonMidnight = MIDNIGHT_2021_UTC + (13 * 3600 * 1000L)
+                + (45 * 60 * 1000L) + (30 * 1000L);
+        String time = TrackDateTimeFormatter.formatTime(
+                nonMidnight, tz, Locale.US);
+        assertEquals("13:45:30Z", time);
+    }
+
+    @Test
+    public void test_formatDate_utc_non_midnight_same_day() {
+        TimeZone tz = TrackDateTimeFormatter.resolveTimeZone("UTC");
+        long afternoon = MIDNIGHT_2021_UTC + (15 * 3600 * 1000L);
+        String date = TrackDateTimeFormatter.formatDate(
+                afternoon, tz, Locale.US);
+        assertEquals("2021-01-01", date);
+    }
+}


### PR DESCRIPTION
## Summary

Track detail timestamps in `TrackDetailsView` are hardcoded to UTC. This adds a user-configurable timezone preference so timestamps can be displayed in either UTC or local device time.

Addresses https://github.com/deptofdefense/AndroidTacticalAssaultKit-CIV/issues/324

## Changes

- New `TrackDateTimeFormatter` utility class that resolves the timezone preference and formats date/time strings with the correct timezone suffix ("Z" for UTC, abbreviation like "EST" for local)
- Modified `TrackDetailsView.setStartDateTime()` to read the `track_history_timezone` preference on each call and delegate formatting to `TrackDateTimeFormatter`
- Added `PanListPreference` to `bread_preferences.xml` with "UTC" (default) and "Local Device Time" options
- Added string and array resources for the new preference

## Scope

Only the display formatting in `TrackDetailsView` is changed. The following are intentionally left unchanged:
- `TrackSearchView` UTC usage (serves a different purpose: date-range-to-epoch conversion for DB queries)
- Export serializers (UTC per KML/GPX interchange standards)
- Crumb database storage format (UTC epoch millis)

## Testing

- 17 JUnit 4 unit tests in `TrackDateTimeFormatterTest` covering UTC formatting, local timezone with day boundary crossing (America/New_York), positive UTC offset (Asia/Kolkata), unrecognized/null/empty preference fallback to UTC, and literal "Z" suffix behavior
- Default value is "UTC", preserving existing behavior for all current users

## Files Changed

- `atak/ATAK/app/src/main/java/com/atakmap/android/track/ui/TrackDateTimeFormatter.java` (new)
- `atak/ATAK/app/src/main/java/com/atakmap/android/track/ui/TrackDetailsView.java`
- `atak/ATAK/app/src/main/res/xml/bread_preferences.xml`
- `atak/ATAK/app/src/main/res/values/strings.xml`
- `atak/ATAK/app/src/main/res/values/arrays.xml`
- `atak/ATAK/app/src/test/java/com/atakmap/android/track/ui/TrackDateTimeFormatterTest.java` (new)